### PR TITLE
Update projects to target .NET 4.5

### DIFF
--- a/IntegrationTests/Loggly.EntLib.IntegrationTests.csproj
+++ b/IntegrationTests/Loggly.EntLib.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Loggly.EntLib.IntegrationTests</RootNamespace>
     <AssemblyName>Loggly.EntLib.IntegrationTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Sample/Loggly.EntLib.Sample.csproj
+++ b/Sample/Loggly.EntLib.Sample.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Loggly.EntLib.Sample</RootNamespace>
     <AssemblyName>Loggly.EntLib.Sample</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/TraceListeners/Loggly.EntLib.TraceListeners.csproj
+++ b/TraceListeners/Loggly.EntLib.TraceListeners.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Loggly.EntLib.TraceListeners</RootNamespace>
     <AssemblyName>Loggly.EntLib.TraceListeners</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/UnitTests/Loggly.EntLib.UnitTests.csproj
+++ b/UnitTests/Loggly.EntLib.UnitTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Loggly.EntLib.UnitTests</RootNamespace>
     <AssemblyName>Loggly.EntLib.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- target .NET Framework 4.5 in TraceListeners, Sample, IntegrationTests, and UnitTests projects

## Testing
- `msbuild Loggly.EntLib.sln /t:Rebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68930e73bd308320b783f454d57f4a37